### PR TITLE
Fix incorrect address

### DIFF
--- a/IPXManagerClass.h
+++ b/IPXManagerClass.h
@@ -14,7 +14,7 @@ public:
 	virtual ~IPXManagerClass() RX;
 
 	ConnectionClass* SetTiming(int retrydelta, int maxretries, int timeout, bool a5)
-		{ JMP_THIS(0x7B30B0) }
+		{ JMP_THIS(0x540C60) }
 
 	int ResponseTime()
 		{ JMP_THIS(0x542450) }


### PR DESCRIPTION
'IPXManagerClass::SetTiming' is using an incorrect address for a long time, which may lead to fatal errors for spawner.